### PR TITLE
SRWLIB_ExampleViewDataFile.py: fix SyntaxError

### DIFF
--- a/vinyl_srw/SRWLIB_ExampleViewDataFile.py
+++ b/vinyl_srw/SRWLIB_ExampleViewDataFile.py
@@ -4,10 +4,9 @@
 # v 0.04
 # Authors: O.C., Maksim Rakitin
 #############################################################################
-
+from __future__ import print_function #Python 2.7 compatibility
 import optparse
 import os
-from __future__ import print_function #Python 2.7 compatibility
 from vinyl_srw.uti_plot import uti_plot_init, uti_plot_data_file, uti_plot_show
 
 if __name__=='__main__':


### PR DESCRIPTION
Fixes:

compiling .pyc files...
  File "lib/python3.6/site-packages/vinyl_srw/SRWLIB_ExampleViewDataFile.py", line 10
    from __future__ import print_function #Python 2.7 compatibility
                                                                  ^
SyntaxError: from __future__ imports must occur at the beginning of the file